### PR TITLE
Handling exceptions in Beyn

### DIFF
--- a/quatrex/OBC/beyn_dace.py
+++ b/quatrex/OBC/beyn_dace.py
@@ -243,241 +243,255 @@ def beyn(M00, M01, M10, imag_lim, R, type: str = 'L', function: str = 'W', block
     LP1 = np.empty((N, NM), dtype=np.complex128)
     RP0 = np.empty((NM, N), dtype=np.complex128)
     RP1 = np.empty((NM, N), dtype=np.complex128)
-    contour_integral(
-        LP0=LP0, LP1=LP1, RP0=RP0, RP1=RP1,
-        M00=M00, M01=M01, M10=M10, Y=Y, R=R, is_left=np.bool_(type=='L'), N=N, NM=NM)
 
-    if validate:
+    try:
 
-        theta = np.linspace(theta_min, theta_max, NT)
-        dtheta = np.hstack((theta[1]-theta[0], theta[2:]-theta[:-2], theta[-1]-theta[-2]))/2
+        contour_integral(
+            LP0=LP0, LP1=LP1, RP0=RP0, RP1=RP1,
+            M00=M00, M01=M01, M10=M10, Y=Y, R=R, is_left=np.bool_(type=='L'), N=N, NM=NM)
 
-        c = 0
-        r1 = 3.0
-        r2 = 1/R
+        if validate:
 
-        zC1 = c + r1*np.exp(1j*theta)
-        zC2 = c + r2*np.exp(1j*theta)
-        z = np.hstack((zC1, zC2))
+            theta = np.linspace(theta_min, theta_max, NT)
+            dtheta = np.hstack((theta[1]-theta[0], theta[2:]-theta[:-2], theta[-1]-theta[-2]))/2
 
-        dzC1_dtheta = 1j*r1*np.exp(1j*theta)
-        dzC2_dtheta = 1j*r2*np.exp(1j*theta)
-        dz_dtheta = np.hstack((dzC1_dtheta, -dzC2_dtheta))
+            c = 0
+            r1 = 3.0
+            r2 = 1/R
 
-        dtheta = np.hstack((dtheta, dtheta))
+            zC1 = c + r1*np.exp(1j*theta)
+            zC2 = c + r2*np.exp(1j*theta)
+            z = np.hstack((zC1, zC2))
 
-        P0 = np.zeros((N, N), dtype=np.complex128)
-        P1 = np.zeros((N, N), dtype=np.complex128)
+            dzC1_dtheta = 1j*r1*np.exp(1j*theta)
+            dzC2_dtheta = 1j*r2*np.exp(1j*theta)
+            dz_dtheta = np.hstack((dzC1_dtheta, -dzC2_dtheta))
 
-        if block:
+            dtheta = np.hstack((dtheta, dtheta))
+
+            P0 = np.zeros((N, N), dtype=np.complex128)
+            P1 = np.zeros((N, N), dtype=np.complex128)
+
+            if block:
+                
+                A = M00[:N//2, :N//2]
+                B = M00[:N//2, N//2:]
+                C = M00[N//2:, :N//2]
+                D = M00[N//2:, N//2:]
+
+                iA = np.linalg.inv(A)
+                iD = np.linalg.inv(D)
+
+                iT = np.empty((N, N), dtype=np.complex128)
+
+                for I in range(len(z)):
+
+                    if type == 'L':
+                        Bi = B + M10[:N//2, N//2:]*z[I]
+                        Ci = C + M01[N//2:, :N//2]/z[I]
+                    else:
+                        Bi = B + M10[:N//2, N//2:]/z[I]
+                        Ci = C + M01[N//2:, :N//2]*z[I]
+
+                    T0 = np.linalg.inv(A - Bi@iD@Ci)
+                    T1 = np.linalg.inv(D - Ci@iA@Bi)
+
+                    iT[:N//2, :N//2] = T0
+                    iT[:N//2, N//2:] = -iA@Bi@T1
+                    iT[N//2:, :N//2] = -iD@Ci@T0
+                    iT[N//2:, N//2:] = T1
+
+                    P0 += iT*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
+                    P1 += iT*z[I]*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
+
+            else:
+
+                for I in range(len(z)):
+
+                    if type == 'L':
+                        T = M00 + M01/z[I] + M10*z[I]
+                    else:
+                        T = M00 + M01*z[I] + M10/z[I]
+
+                    iT = np.linalg.inv(T)
+
+                    P0 += iT*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
+                    P1 += iT*z[I]*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
+
+            LP0_ref = P0@Y
+            LP1_ref = P1@Y
+
+            RP0_ref = Y.T@P0
+            RP1_ref = Y.T@P1
+
             
-            A = M00[:N//2, :N//2]
-            B = M00[:N//2, N//2:]
-            C = M00[N//2:, :N//2]
-            D = M00[N//2:, N//2:]
+            error = False
+            for n, val, ref in zip(['LP0', 'LP1', 'RP0', 'RP1'], [LP0, LP1, RP0, RP1], [LP0_ref, LP1_ref, RP0_ref, RP1_ref]):
+                if not np.allclose(val, ref):
+                    error = True
+                    print(f"Validation failed for {n} with relerror {np.linalg.norm(val-ref)/np.linalg.norm(ref)}!")
+            # if not error:
+            #     print("Validation successful!")
 
-            iA = np.linalg.inv(A)
-            iD = np.linalg.inv(D)
+        # ctime += time.perf_counter()
+        # print(f'Time for contour integral (DaCe): {ctime} s')
 
-            iT = np.empty((N, N), dtype=np.complex128)
+        # ctime = - time.perf_counter()
 
-            for I in range(len(z)):
+        LV, LS, LW = svd(LP0, full_matrices=False)
+        Lind = np.where(abs(np.diag(LS)) > eps_lim)[0]
 
-                if type == 'L':
-                    Bi = B + M10[:N//2, N//2:]*z[I]
-                    Ci = C + M01[N//2:, :N//2]/z[I]
-                else:
-                    Bi = B + M10[:N//2, N//2:]/z[I]
-                    Ci = C + M01[N//2:, :N//2]*z[I]
+        RV, RS, RW = svd(RP0, full_matrices=True)
+        Rind = np.where(abs(np.diag(RS)) > eps_lim)[0]
 
-                T0 = np.linalg.inv(A - Bi@iD@Ci)
-                T1 = np.linalg.inv(D - Ci@iA@Bi)
+        # ctime += time.perf_counter()
+        # print(f'Time for SVD (DaCe): {ctime} s')
 
-                iT[:N//2, :N//2] = T0
-                iT[:N//2, N//2:] = -iA@Bi@T1
-                iT[N//2:, :N//2] = -iD@Ci@T0
-                iT[N//2:, N//2:] = T1
+        if len(Lind) == 0:
 
-                P0 += iT*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
-                P1 += iT*z[I]*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
+            cond = np.nan
+            ksurf = None
+            Sigma = None
+            gR = None
 
         else:
 
-            for I in range(len(z)):
+            # ctime = - time.perf_counter()
 
-                if type == 'L':
-                    T = M00 + M01/z[I] + M10*z[I]
-                else:
-                    T = M00 + M01*z[I] + M10/z[I]
+            LV = LV[:, Lind]
+            LS = LS[Lind]
+            LW = np.conj(LW).T[:, Lind]
 
-                iT = np.linalg.inv(T)
+            Llambda, Lu = np.linalg.eig(np.conj(LV).T@LP1@LW@np.linalg.inv(np.diag(LS)))
+            #Llambda = np.diag(Llambda)
+            phiL = LV@Lu
 
-                P0 += iT*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
-                P1 += iT*z[I]*dz_dtheta[I]*dtheta[I]/(2*np.pi*1j)
+            RV = RV[:, Rind]
+            RS = RS[Rind]
+            RW = np.conj(RW).T[:, Rind]
 
-        LP0_ref = P0@Y
-        LP1_ref = P1@Y
+            Rlambda, Ru = np.linalg.eig(np.linalg.inv(np.diag(RS))@np.conj(RV).T@RP1@RW)
+            #Rlambda = np.diag(Rlambda)
+            phiR = np.linalg.solve(Ru, np.conj(RW).T)
 
-        RP0_ref = Y.T@P0
-        RP1_ref = Y.T@P1
+            if type == 'L':
+                kL = 1j * np.log(Llambda)
+                kR = 1j * np.log(Rlambda)
+            else:
+                kL = -1j * np.log(Llambda)
+                kR = -1j * np.log(Rlambda)
 
-        
-        error = False
-        for n, val, ref in zip(['LP0', 'LP1', 'RP0', 'RP1'], [LP0, LP1, RP0, RP1], [LP0_ref, LP1_ref, RP0_ref, RP1_ref]):
-            if not np.allclose(val, ref):
-                error = True
-                print(f"Validation failed for {n} with relerror {np.linalg.norm(val-ref)/np.linalg.norm(ref)}!")
-        # if not error:
-        #     print("Validation successful!")
+            ind_sort_kL = np.argsort(abs(np.imag(kL)))
+            k = kL[ind_sort_kL]
+            phiL = phiL[:, ind_sort_kL].copy()
 
-    # ctime += time.perf_counter()
-    # print(f'Time for contour integral (DaCe): {ctime} s')
+            # ctime += time.perf_counter()
+            # print(f'Time for eigenvalue problem (DaCe): {ctime} s')
 
-    # ctime = - time.perf_counter()
+            # ksurf, Vsurf, dEk_dk, Nref, gR, Sigma, Vs = calc_sigma(
+            #     k=k, kR=kR, phiL=phiL, phiR=phiR, M00=M00, M01=M01, M10=M10, imag_lim=imag_lim,
+            #     is_left=type=='L', is_W=function=='W', ref_iteration=ref_iteration,
+            #     N=N, NM=NM)
+            # ksurf = ksurf[:Nref[0]]
+            # Vsurf = Vsurf[:,:Nref[0]]
 
-    LV, LS, LW = svd(LP0, full_matrices=False)
-    Lind = np.where(abs(np.diag(LS)) > eps_lim)[0]
+            # assert np.allclose(Vs, Vsurf)
 
-    RV, RS, RW = svd(RP0, full_matrices=True)
-    Rind = np.where(abs(np.diag(RS)) > eps_lim)[0]
+            # ctime = - time.perf_counter()
 
-    # ctime += time.perf_counter()
-    # print(f'Time for SVD (DaCe): {ctime} s')
+            if type == 'L':
+                ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, imag_lim, 1.0)
+                gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
+                for IC in range(ref_iteration):
+                    gR = np.linalg.inv(M00 - M10 @ gR @ M01)
+                if(np.imag(np.trace(gR)) > 0 and function == 'G'):
+                        ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, 0.5, 1.0)
+                        gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
+                        for IC in range(ref_iteration):
+                            gR = np.linalg.inv(M00 - M10 @ gR @ M01)
+                Sigma = M10 @ gR @ M01
+            else:
+                ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, imag_lim, -1.0)
+                gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
+                for IC in range(ref_iteration):
+                    gR = np.linalg.inv(M00 - M01 @ gR @ M10)
+                if(np.imag(np.trace(gR)) > 0 and function == 'G'):
+                        ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, 0.5, -1.0)
+                        gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
+                        for IC in range(ref_iteration):
+                            gR = np.linalg.inv(M00 - M01 @ gR @ M10)
+                Sigma = M01 @ gR @ M10
 
-    if len(Lind) == 0:
+            # ksurf_buf = np.empty((NM,), dtype=np.complex128)
+            # Vsurf_buf = np.empty((N, NM), dtype=np.complex128)
+            # dEk_dk = np.empty((NM,), dtype=np.complex128)
+            # Nref = np.empty((1,), dtype=np.int32)
+
+            # if type == 'L':
+
+            #     # ksurf, Vsurf, dEk_dk, Nref = sortk(k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=imag_lim, factor=1.0, N=N, NM=NM)
+            #     sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
+            #           k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=imag_lim, factor=1.0, N=N, NM=NM)
+            #     ksurf = ksurf_buf[0:Nref[0]]
+            #     Vsurf = Vsurf_buf[:,0:Nref[0]]
+
+            #     gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
+            #     for IC in range(ref_iteration):
+            #         gR = np.linalg.inv(M00 - M10 @ gR @ M01)
+
+            #     if(np.imag(np.trace(gR)) > 0 and function == 'G'):
+                    
+            #         sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
+            #               k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=0.5, factor=1.0, N=N, NM=NM)
+            #         ksurf = ksurf_buf[0:Nref[0]]
+            #         Vsurf = Vsurf_buf[:,0:Nref[0]]
+                    
+            #         gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
+            #         for IC in range(ref_iteration):
+            #             gR = np.linalg.inv(M00 - M10 @ gR @ M01)
+
+            #     Sigma = M10 @ gR @ M01
+            # else:
+
+            #     sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
+            #           k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=imag_lim, factor=-1.0, N=N, NM=NM)
+            #     ksurf = ksurf_buf[0:Nref[0]]
+            #     Vsurf = Vsurf_buf[:,0:Nref[0]]
+
+            #     gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
+            #     for IC in range(ref_iteration):
+            #         gR = np.linalg.inv(M00 - M01 @ gR @ M10)
+
+            #     if(np.imag(np.trace(gR)) > 0 and function == 'G'):
+
+            #         sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
+            #               k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=0.5, factor=-1.0, N=N, NM=NM)
+            #         ksurf = ksurf_buf[0:Nref[0]]
+            #         Vsurf = Vsurf_buf[:,0:Nref[0]]
+
+            #         gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
+            #         for IC in range(ref_iteration):
+            #             gR = np.linalg.inv(M00 - M01 @ gR @ M10)
+
+            #     Sigma = M01 @ gR @ M10
+            
+            # ctime += time.perf_counter()
+            # print(f'Time for Sigma (DaCe): {ctime} s')
+
+            ind = np.where(abs(dEk_dk))
+            if len(ind[0]) > 0:
+                min_dEk = np.min(abs(dEk_dk[ind]))
+    
+    except Exception as e:
+
+        print("Error in Beyn:")
+        print(e)
 
         cond = np.nan
         ksurf = None
         Sigma = None
         gR = None
 
-    else:
-
-        # ctime = - time.perf_counter()
-
-        LV = LV[:, Lind]
-        LS = LS[Lind]
-        LW = np.conj(LW).T[:, Lind]
-
-        Llambda, Lu = np.linalg.eig(np.conj(LV).T@LP1@LW@np.linalg.inv(np.diag(LS)))
-        #Llambda = np.diag(Llambda)
-        phiL = LV@Lu
-
-        RV = RV[:, Rind]
-        RS = RS[Rind]
-        RW = np.conj(RW).T[:, Rind]
-
-        Rlambda, Ru = np.linalg.eig(np.linalg.inv(np.diag(RS))@np.conj(RV).T@RP1@RW)
-        #Rlambda = np.diag(Rlambda)
-        phiR = np.linalg.solve(Ru, np.conj(RW).T)
-
-        if type == 'L':
-            kL = 1j * np.log(Llambda)
-            kR = 1j * np.log(Rlambda)
-        else:
-            kL = -1j * np.log(Llambda)
-            kR = -1j * np.log(Rlambda)
-
-        ind_sort_kL = np.argsort(abs(np.imag(kL)))
-        k = kL[ind_sort_kL]
-        phiL = phiL[:, ind_sort_kL].copy()
-
-        # ctime += time.perf_counter()
-        # print(f'Time for eigenvalue problem (DaCe): {ctime} s')
-
-        # ksurf, Vsurf, dEk_dk, Nref, gR, Sigma, Vs = calc_sigma(
-        #     k=k, kR=kR, phiL=phiL, phiR=phiR, M00=M00, M01=M01, M10=M10, imag_lim=imag_lim,
-        #     is_left=type=='L', is_W=function=='W', ref_iteration=ref_iteration,
-        #     N=N, NM=NM)
-        # ksurf = ksurf[:Nref[0]]
-        # Vsurf = Vsurf[:,:Nref[0]]
-
-        # assert np.allclose(Vs, Vsurf)
-
-        # ctime = - time.perf_counter()
-
-        if type == 'L':
-            ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, imag_lim, 1.0)
-            gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
-            for IC in range(ref_iteration):
-                gR = np.linalg.inv(M00 - M10 @ gR @ M01)
-            if(np.imag(np.trace(gR)) > 0 and function == 'G'):
-                    ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, 0.5, 1.0)
-                    gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
-                    for IC in range(ref_iteration):
-                        gR = np.linalg.inv(M00 - M10 @ gR @ M01)
-            Sigma = M10 @ gR @ M01
-        else:
-            ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, imag_lim, -1.0)
-            gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
-            for IC in range(ref_iteration):
-                gR = np.linalg.inv(M00 - M01 @ gR @ M10)
-            if(np.imag(np.trace(gR)) > 0 and function == 'G'):
-                    ksurf, Vsurf, dEk_dk = sort_k(k, kR, phiL, phiR, M01, M10, 0.5, -1.0)
-                    gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
-                    for IC in range(ref_iteration):
-                        gR = np.linalg.inv(M00 - M01 @ gR @ M10)
-            Sigma = M01 @ gR @ M10
-
-        # ksurf_buf = np.empty((NM,), dtype=np.complex128)
-        # Vsurf_buf = np.empty((N, NM), dtype=np.complex128)
-        # dEk_dk = np.empty((NM,), dtype=np.complex128)
-        # Nref = np.empty((1,), dtype=np.int32)
-
-        # if type == 'L':
-
-        #     # ksurf, Vsurf, dEk_dk, Nref = sortk(k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=imag_lim, factor=1.0, N=N, NM=NM)
-        #     sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
-        #           k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=imag_lim, factor=1.0, N=N, NM=NM)
-        #     ksurf = ksurf_buf[0:Nref[0]]
-        #     Vsurf = Vsurf_buf[:,0:Nref[0]]
-
-        #     gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
-        #     for IC in range(ref_iteration):
-        #         gR = np.linalg.inv(M00 - M10 @ gR @ M01)
-
-        #     if(np.imag(np.trace(gR)) > 0 and function == 'G'):
-                
-        #         sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
-        #               k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=0.5, factor=1.0, N=N, NM=NM)
-        #         ksurf = ksurf_buf[0:Nref[0]]
-        #         Vsurf = Vsurf_buf[:,0:Nref[0]]
-                
-        #         gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M10 @ Vsurf @ np.diag(np.exp(-1j * ksurf))) @ Vsurf.T
-        #         for IC in range(ref_iteration):
-        #             gR = np.linalg.inv(M00 - M10 @ gR @ M01)
-
-        #     Sigma = M10 @ gR @ M01
-        # else:
-
-        #     sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
-        #           k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=imag_lim, factor=-1.0, N=N, NM=NM)
-        #     ksurf = ksurf_buf[0:Nref[0]]
-        #     Vsurf = Vsurf_buf[:,0:Nref[0]]
-
-        #     gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
-        #     for IC in range(ref_iteration):
-        #         gR = np.linalg.inv(M00 - M01 @ gR @ M10)
-
-        #     if(np.imag(np.trace(gR)) > 0 and function == 'G'):
-
-        #         sortk(ksurf=ksurf_buf, Vsurf=Vsurf_buf, dEk_dk=dEk_dk, out_Nref=Nref,
-        #               k=k, kR=kR, phiL=phiL, phiR=phiR, M01=M01, M10=M10, imag_limit=0.5, factor=-1.0, N=N, NM=NM)
-        #         ksurf = ksurf_buf[0:Nref[0]]
-        #         Vsurf = Vsurf_buf[:,0:Nref[0]]
-
-        #         gR = Vsurf @ np.linalg.inv(Vsurf.T @ M00 @ Vsurf + Vsurf.T @ M01 @ Vsurf @ np.diag(np.exp(1j * ksurf))) @ Vsurf.T
-        #         for IC in range(ref_iteration):
-        #             gR = np.linalg.inv(M00 - M01 @ gR @ M10)
-
-        #     Sigma = M01 @ gR @ M10
-        
-        # ctime += time.perf_counter()
-        # print(f'Time for Sigma (DaCe): {ctime} s')
-
-        ind = np.where(abs(dEk_dk))
-        if len(ind[0]) > 0:
-            min_dEk = np.min(abs(dEk_dk[ind]))
     return ksurf, cond, gR, Sigma, min_dEk
 
 


### PR DESCRIPTION
This PR addresses the issue of various exceptions that may be raised during the computation of the boundary conditions with the Beyn algorithm. Most of the Beyn algorithm is now placed in a try-except block that will print the exception caught and return default (None) values so that the program can proceed with the Sanchez-Rubio algorithm.